### PR TITLE
Uncommenting class methods

### DIFF
--- a/text_cleaning_BW.py
+++ b/text_cleaning_BW.py
@@ -1,7 +1,13 @@
 import re
 
 
-def snippetyielder(docbreaks):
+def snippetyielder(filename):
+	text = open(filename)
+	a = text.readlines()
+	p = "".join(a)
+	docbreak = re.sub(r"(.*SDA.*)",r"\1DOCBREAK",p)
+	docbreaks = docbreak.split("DOCBREAK")
+
 	for doc in docbreaks:
 		yield doc
 			# elif re.match(r"(.*NDA.*)",line):
@@ -41,3 +47,7 @@ def snippetyielder(docbreaks):
 
 
 
+if __name__=="__main__":
+	#f = open("v1.txt", 'r')
+	for snippet in snippetyielder("test.txt"):
+		pass

--- a/text_cleaning_BW.py
+++ b/text_cleaning_BW.py
@@ -1,13 +1,6 @@
 import re
 
 
-#f = open("v1.txt", 'r')
-text = open('test.txt')
-a = text.readlines()
-p = "".join(a)
-docbreak = re.sub(r"(.*SDA.*)",r"\1DOCBREAK",p)
-docbreaks = docbreak.split("DOCBREAK")
-
 def snippetyielder(docbreaks):
 	for doc in docbreaks:
 		yield doc
@@ -36,15 +29,15 @@ def snippetyielder(docbreaks):
  class document:
   	def _init_(self, doc):
   		self.doc = doc
-
-#  	def raw_text:
-
-# 	def metadata:
-
-# 	def get_date:
-
-# 	def does_this_look_suspicious:
-		
+  		
+  	def raw_text(self):
+		pass
+ 	def metadata(self):
+		pass
+ 	def get_date(self):
+		pass
+ 	def does_this_look_suspicious(self):
+		pass
 
 
 


### PR DESCRIPTION
This is the classical way to do define methods that aren't used yet: express them as a function of self, and use `pass` as a placeholder.

You don't need to accept this patch, just wanted to show how it's usually done.
